### PR TITLE
Allow #complete to have auto-complete with tags

### DIFF
--- a/_timew
+++ b/_timew
@@ -61,7 +61,14 @@ function _timew()
     cancel|config|diagnostics|day|extensions|get|month|show|undo|week)
       wordlist=""
       ;;
-    continue|delete|join|lengthen|move|resize|shorten|split)
+    continue)
+      if __is_entering_id ; then
+        wordlist=$( __get_ids )
+      else
+        wordlist=$( __get_tags )
+      fi
+      ;;
+    delete|join|lengthen|move|resize|shorten|split)
       wordlist=$( __get_ids )
       ;;
     export|gaps|start|stop|tags|track)


### PR DESCRIPTION
This PR adds the functionality of also showing the tags (instead of just the ids) to the autocomplete for the `complete` command.